### PR TITLE
Prevent zoom on input fields for mobile devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, initial-scale=1, maximum-scale=1" />
     
     <!-- Basic Meta Tags -->
     <title>Markdown to Image Converter</title>


### PR DESCRIPTION
Fixes #1

Add meta tag to prevent zoom on input fields for mobile devices

* Modify `index.html` to include `user-scalable=no, initial-scale=1, maximum-scale=1` in the `meta` tag to prevent zoom on input fields for mobile devices.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tktcorporation/markdown-to-image-web/pull/3?shareId=5e244e8a-dc19-4fb2-b3c8-152cb7946e5c).