### PR TITLE
Add CI with Github Actions for linter and typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run linter (biome)
+        run: npm run lint
+
+      - name: Run typecheck (tsc)
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "biome check .",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",


### PR DESCRIPTION
Fixes #5

Add CI setup with Github Actions for linter (biome) and typecheck (tsc).

* **package.json**
  - Add script for running the linter (biome) with `npm run lint`.
  - Add script for running the typecheck (tsc) with `npm run typecheck`.

* **.github/workflows/ci.yml**
  - Create a new Github Actions workflow file.
  - Add job to run on push and pull request events.
  - Add steps to install dependencies, run the linter (biome), and run the typecheck (tsc).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tktcorporation/markdown-to-image-web/pull/6?shareId=468e4993-e987-4599-8e3a-80202e50dc96).