### PR TITLE
Fix iOS clipboard issue

### DIFF
--- a/src/services/ImageService.ts
+++ b/src/services/ImageService.ts
@@ -179,7 +179,18 @@ export class ImageService {
     }
 
     const { blob } = await this.processImage(options);
-    const clipboardItem = new ClipboardItem({ [blob.type]: blob });
-    await navigator.clipboard.write([clipboardItem]);
+
+    if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
+      const clipboardItem = new ClipboardItem({ [blob.type]: blob });
+      await navigator.clipboard.write([clipboardItem]);
+    } else {
+      const dataUrl = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result as string);
+        reader.onerror = () => reject(new Error('Failed to read image data'));
+        reader.readAsDataURL(blob);
+      });
+      await navigator.clipboard.writeText(dataUrl);
+    }
   }
 }

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -7,6 +7,14 @@ interface ClipboardError extends Error {
   name: string;
 }
 
+const blobToDataURL = (blob: Blob): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Failed to read image data'));
+    reader.readAsDataURL(blob);
+  });
+
 const getDetailedErrorMessage = (error: ClipboardError): string => {
   switch (error.name) {
     case 'NotAllowedError':
@@ -89,12 +97,13 @@ export const copyImageToClipboard = async (
         );
       });
 
-      // Create ClipboardItem and write to clipboard
-      const clipboardItem = new ClipboardItem({
-        [blob.type]: blob
-      });
-
-      await navigator.clipboard.write([clipboardItem]);
+      if (typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
+        const clipboardItem = new ClipboardItem({ [blob.type]: blob });
+        await navigator.clipboard.write([clipboardItem]);
+      } else {
+        const dataUrl = await blobToDataURL(blob);
+        await navigator.clipboard.writeText(dataUrl);
+      }
     } catch (error) {
       throw new Error(`Failed to process image: ${(error as Error).message}`);
     } finally {


### PR DESCRIPTION
## Summary
- handle browsers that don't support ClipboardItem when copying
- provide fallback for iOS by copying the image as a data URL

## Testing
- `npm run build`
